### PR TITLE
Dates and log rolling

### DIFF
--- a/harvester/HarvestLogger.py
+++ b/harvester/HarvestLogger.py
@@ -10,7 +10,12 @@ class HarvestLogger:
 		if not os.path.exists(self.logdir):
 			os.makedirs(self.logdir)
 
-		self.handler = TimedRotatingFileHandler(params['filename'], when="D", interval=params['daysperfile'], backupCount=params['keep'])
+		self.handler = TimedRotatingFileHandler(
+			params['filename'],
+			when="D",
+			interval=int(params['daysperfile']),
+			backupCount=int(params['keep'])
+		)
 		logFormatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 		self.handler.setFormatter(logFormatter)
 		self.logger = logging.getLogger("Rotating Log")

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -175,7 +175,13 @@ class OAIRepository(HarvestRepository):
 
 		# If dates are entirely numeric, add separators
 		if not re.search("\D", record["date"]):
-			record["date"] = record["date"][0] + record["date"][1] + record["date"][2] + record["date"][3] + "-" + record["date"][4] + record["date"][5] + "-" + record["date"][6] + record["date"][7]
+			self.logger.debug("Trying to reformat date: %s" % (record["date"]))
+			if (len(record["date"]) == 4):
+				record["date"] = record["date"][0] + record["date"][1] + record["date"][2] + record["date"][3] + "-01-01"
+			if (len(record["date"]) == 6):
+				record["date"] = record["date"][0] + record["date"][1] + record["date"][2] + record["date"][3] + "-" + record["date"][4] + record["date"][5] + "-01"
+			if (len(record["date"]) == 8):
+				record["date"] = record["date"][0] + record["date"][1] + record["date"][2] + record["date"][3] + "-" + record["date"][4] + record["date"][5] + "-" + record["date"][6] + record["date"][7]
 
 		if isinstance(record["title"], list):
 			record["title"] = record["title"][0]

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -175,7 +175,13 @@ class OAIRepository(HarvestRepository):
 
 		# If dates are entirely numeric, add separators
 		if not re.search("\D", record["date"]):
-			record["date"] = record["date"][0] + record["date"][1] + record["date"][2] + record["date"][3] + "-" + record["date"][4] + record["date"][5] + "-" + record["date"][6] + record["date"][7]
+			self.logger.debug("Trying to reformat date: %s" % (record["date"]))
+			if (len(record["date"]) == 4):
+				record["date"] = record["date"][0] + record["date"][1] + record["date"][2] + record["date"][3] + "-01-01"
+			if (len(record["date"]) == 6):
+				record["date"] = record["date"][0] + record["date"][1] + record["date"][2] + record["date"][3] + "-" + record["date"][4] + record["date"][5] + "-01"
+			if (len(record["date"]) == 7):
+				record["date"] = record["date"][0] + record["date"][1] + record["date"][2] + record["date"][3] + "-" + record["date"][4] + record["date"][5] + "-" + record["date"][6] + record["date"][7]
 
 		if isinstance(record["title"], list):
 			record["title"] = record["title"][0]


### PR DESCRIPTION
Code was failing for dates like "1998".  Added checks for various lengths of numeric-only dates.

Logs not rolling properly on Alpha, and according to others it may be because the arguments to TimedRotatingFileHandler need to be ints.  Not sure this will fix it, but it won't hurt.