### PR TITLE
Change to integers for all table primary keys

### DIFF
--- a/globus_harvester.py
+++ b/globus_harvester.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 	configs['repo_refresh_days'] = configs.get('repo_refresh_days', 1)
 	configs['temp_filepath'] = configs.get('temp_filepath', "temp")
 	configs['export_filepath'] = configs.get('export_filepath', "data")
-	configs['export_batch_size'] = configs.get('export_batch_size', 10000)
+	configs['export_batch_size'] = configs.get('export_batch_size', 8000)
 	configs['export_format'] = configs.get('export_format', "gmeta")
 
 	main_log = HarvestLogger(configs['logging'])

--- a/harvester/CKANRepository.py
+++ b/harvester/CKANRepository.py
@@ -69,7 +69,10 @@ class CKANRepository(HarvestRepository):
 		record["subject"] = ckan_record.get('subject',"")
 
 		# Open Data Canada API now returns a mangled unicode-escaped-keyed-dict-as-string; regex is the only solution
-		record["dc:source"] = re.search("(http|ftp|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?", ckan_record["url"]).group(0)
+		try:
+			record["dc:source"] = re.search("(http|ftp|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?", ckan_record["url"]).group(0)
+		except:
+			return None
 
 		record["rights"] = [ckan_record['license_title']]
 		record["rights"].append(ckan_record.get("license_url", ""))

--- a/harvester/CKANRepository.py
+++ b/harvester/CKANRepository.py
@@ -21,28 +21,24 @@ class CKANRepository(HarvestRepository):
 				# F gon' give it to ya
 				self.domain_metadata = dmf.readlines()
 		else:
-			self.domain_metadata = []		
+			self.domain_metadata = []
 
 
 	def _crawl(self):
-		self.db.create_repo(self.url, self.name, "ckan", self.thumbnail, self.item_url_pattern)
+		self.repository_id = self.db.update_repo(self.repository_id, self.url, self.set, self.name, "ckan", self.enabled, self.thumbnail, self.item_url_pattern,self.abort_after_numerrors,self.max_records_updated_per_run,self.update_log_after_numitems,self.record_refresh_days,self.repo_refresh_days)
 		records = self.ckanrepo.action.package_list()
 
-		item_existing_count = 0
-		item_new_count = 0
-		for record_id in records:
-			result = self.db.write_header(record_id, self.url)
-			if result == None:
-				item_existing_count = item_existing_count + 1
-			else:
-				item_new_count = item_new_count + 1
-			if ((item_existing_count + item_new_count) % self.update_log_after_numitems == 0):
+		item_count = 0
+		for ckan_identifier in records:
+			result = self.db.write_header(ckan_identifier, self.repository_id)
+			item_count = item_count + 1
+			if (item_count % self.update_log_after_numitems == 0):
 				tdelta = time.time() - self.tstart + 0.1
-				self.logger.info("Done %s item headers after %s (%.1f items/sec)" % ((item_existing_count + item_new_count), self.formatter.humanize(tdelta), ((item_existing_count + item_new_count)/tdelta)) )
+				self.logger.info("Done %s item headers after %s (%.1f items/sec)" % (item_count, self.formatter.humanize(tdelta), item_count/tdelta) )
 
-		self.logger.info("Found %s items in feed (%d existing, %d new)" % ((item_existing_count + item_new_count), item_existing_count, item_new_count) )
+		self.logger.info("Found %s items in feed" % (item_count) )
 
-	def format_ckan_to_oai(self,ckan_record, local_identifier):
+	def format_ckan_to_oai(self, ckan_record, local_identifier):
 		record = {}
 
 		if not 'date_published' in ckan_record:
@@ -81,7 +77,7 @@ class CKANRepository(HarvestRepository):
 		record["rights"] = " - ".join(record["rights"])
 
 		# Some CKAN records have a trailing null timestamp after date
-		record["date"] = re.sub(" 00:00:00", "", ckan_record['date_published'])
+		record["pub_date"] = re.sub(" 00:00:00", "", ckan_record['date_published'])
 
 		record["contact"] = ckan_record.get("author_email", ckan_record.get("maintainer_email", ""))
 
@@ -138,13 +134,13 @@ class CKANRepository(HarvestRepository):
 
 	@_rate_limited(5)
 	def _update_record(self,record):
-		self.logger.debug("Updating CKAN record %s from repo at %s" % (record['local_identifier'],self.url) )
+		#self.logger.debug("Updating CKAN record %s" % (record['local_identifier']) )
 
 		try:
 			ckan_record = self.ckanrepo.action.package_show(id=record['local_identifier'])
 			oai_record = self.format_ckan_to_oai(ckan_record,record['local_identifier'])
 			if oai_record:
-				self.db.write_record(oai_record, self.url, self.metadataprefix.lower(), self.domain_metadata, "replace")
+				self.db.write_record(oai_record, self.repository_id, self.metadataprefix.lower(), self.domain_metadata)
 			return True
 
 		except ckanapi.errors.NotAuthorized:

--- a/harvester/DBInterface.py
+++ b/harvester/DBInterface.py
@@ -242,7 +242,7 @@ class DBInterface:
 				cur.execute(self._prep("UPDATE records set title=?, pub_date=?, contact=?, series=?, modified_timestamp=?, source_url=?, deleted=?, local_identifier=? WHERE record_id = ?"),
 					(record["title"], record["pub_date"], record["contact"], record["series"], time.time(), source_url, 0, record["identifier"], record["record_id"]) )
 
-			if record["record_id"] == None:
+			if record["record_id"] is None:
 				return None
 
 			if "creator" in record:

--- a/harvester/DBInterface.py
+++ b/harvester/DBInterface.py
@@ -196,7 +196,7 @@ class DBInterface:
 		return True
 
 	def get_record_id(self, repo_id, local_identifier):
-		returnvalue = 0
+		returnvalue = None
 		con = self.getConnection()
 		with con:
 			if self.dbtype == "sqlite":
@@ -209,7 +209,7 @@ class DBInterface:
 			if cur is not None:
 				records = cur.fetchall()
 			else:
-				return 0
+				return None
 			for record in records:
 				returnvalue = int(record['record_id'])
 		return returnvalue		
@@ -225,7 +225,7 @@ class DBInterface:
 			source_url = ""
 			if 'dc:source' in record:
 				source_url = record["dc:source"]
-			if record["record_id"] == 0:
+			if record["record_id"] is None:
 				try:
 					if self.dbtype == "postgres":
 						cur.execute(self._prep("INSERT INTO records (title, pub_date, contact, series, modified_timestamp, source_url, deleted, local_identifier, repository_id) VALUES(?,?,?,?,?,?,?,?,?) RETURNING record_id"), 
@@ -242,7 +242,7 @@ class DBInterface:
 				cur.execute(self._prep("UPDATE records set title=?, pub_date=?, contact=?, series=?, modified_timestamp=?, source_url=?, deleted=?, local_identifier=? WHERE record_id = ?"),
 					(record["title"], record["pub_date"], record["contact"], record["series"], time.time(), source_url, 0, record["identifier"], record["record_id"]) )
 
-			if record["record_id"] == 0:
+			if record["record_id"] == None:
 				return None
 
 			if "creator" in record:

--- a/harvester/DBInterface.py
+++ b/harvester/DBInterface.py
@@ -246,94 +246,123 @@ class DBInterface:
 				return None
 
 			if "creator" in record:
+				try:
+					# TODO: figure out a cleaner way to remove related table data other than just purging it all each time
+					cur.execute(self._prep("DELETE from creators where record_id = ? and is_contributor=0"), (record["record_id"],))
+				except:
+					pass
 				if not isinstance(record["creator"], list):
 					record["creator"] = [record["creator"]]
 				for creator in record["creator"]:
 					try:
-						cur.execute(self._prep("DELETE from creators where record_id = ? and is_contributor=0"), (record["record_id"],))
 						cur.execute(self._prep("INSERT INTO creators (record_id, creator, is_contributor) VALUES (?,?,?)"), (record["record_id"], creator, 0))
 					except self.dblayer.IntegrityError:
 						pass
 
 			if "contributor" in record:
+				try:
+					cur.execute(self._prep("DELETE from creators where record_id = ? and is_contributor=1"), (record["record_id"],))
+				except:
+					pass
 				if not isinstance(record["contributor"], list):
 					record["contributor"] = [record["contributor"]]
 				for creator in record["contributor"]:
 					try:
-						cur.execute(self._prep("DELETE from creators where record_id = ? and is_contributor=1"), (record["record_id"],))
 						cur.execute(self._prep("INSERT INTO creators (record_id, creator, is_contributor) VALUES (?,?,?)"), (record["record_id"], creator, 1))
 					except self.dblayer.IntegrityError:
 						pass
 
 			if "subject" in record:
+				try:
+					cur.execute(self._prep("DELETE from subjects where record_id = ?"), (record["record_id"],))
+				except:
+					pass
 				if not isinstance(record["subject"], list):
 					record["subject"] = [record["subject"]]
 				for subject in record["subject"]:
 					try:
-						cur.execute(self._prep("DELETE from subjects where record_id = ?"), (record["record_id"],))
 						if subject is not None and len(subject) > 0:
 							cur.execute(self._prep("INSERT INTO subjects (record_id, subject) VALUES (?,?)"), (record["record_id"], subject))
 					except self.dblayer.IntegrityError:
 						pass
 
 			if "rights" in record:
+				try:
+					cur.execute(self._prep("DELETE from rights where record_id = ?"), (record["record_id"],))
+				except:
+					pass
 				if not isinstance(record["rights"], list):
 					record["rights"] = [record["rights"]]
 				for rights in record["rights"]:
 					try:
-						cur.execute(self._prep("DELETE from rights where record_id = ?"), (record["record_id"],))
 						cur.execute(self._prep("INSERT INTO rights (record_id, rights) VALUES (?,?)"), (record["record_id"], rights))
 					except self.dblayer.IntegrityError:
 						pass
 
 			if "description" in record:
+				try:
+					cur.execute(self._prep("DELETE from descriptions where record_id = ? and language='en' "), (record["record_id"],))
+				except:
+					pass
 				if not isinstance(record["description"], list):
 					record["description"] = [record["description"]]
 				for description in record["description"]:
 					try:
-						cur.execute(self._prep("DELETE from descriptions where record_id = ? and language='en' "), (record["record_id"],))
 						cur.execute(self._prep("INSERT INTO descriptions (record_id, description, language) VALUES (?,?,?)"), (record["record_id"], description, 'en'))
 					except self.dblayer.IntegrityError:
 						pass
 
 			if "description_fr" in record:
+				try:
+					cur.execute(self._prep("DELETE from descriptions where record_id = ? and language='fr' "), (record["record_id"],))
+				except:
+					pass
 				if not isinstance(record["description_fr"], list):
 					record["description_fr"] = [record["description_fr"]]
 				for description_fr in record["description_fr"]:
 					try:
-						cur.execute(self._prep("DELETE from descriptions where record_id = ? and language='fr' "), (record["record_id"],))
 						cur.execute(self._prep("INSERT INTO descriptions (record_id, description, language) VALUES (?,?,?)"), (record["record_id"], description_fr, 'fr'))
 					except self.dblayer.IntegrityError:
 						pass
 
 			if "tags" in record:
+				try:
+					cur.execute(self._prep("DELETE from tags where record_id = ? and language='en' "), (record["record_id"],))
+				except:
+					pass
 				if not isinstance(record["tags"], list):
 					record["tags"] = [record["tags"]]
 				for tag in record["tags"]:
 					try:
-						cur.execute(self._prep("DELETE from tags where record_id = ? and language='en' "), (record["record_id"],))
 						cur.execute(self._prep("INSERT INTO tags (record_id, tag, language) VALUES (?,?,?)"), (record["record_id"], tag, "en"))
 					except self.dblayer.IntegrityError:
 						pass
 
 			if "tags_fr" in record:
+				try:
+					cur.execute(self._prep("DELETE from tags where record_id = ? and language='fr' "), (record["record_id"],))
+				except:
+					pass
 				if not isinstance(record["tags_fr"], list):
 					record["tags_fr"] = [record["tags_fr"]]
 				for tag_fr in record["tags_fr"]:
 					try:
-						cur.execute(self._prep("DELETE from tags where record_id = ? and language='fr' "), (record["record_id"],))
 						cur.execute(self._prep("INSERT INTO tags (record_id, tag, language) VALUES (?,?,?)"), (record["record_id"], tag_fr, "fr"))
 					except self.dblayer.IntegrityError:
 						pass
 
 			if "geospatial" in record:
+				try:
+					cur.execute(self._prep("DELETE from geospatial where record_id = ?"), (record["record_id"],))
+				except:
+					pass
 				for coordinates in record["geospatial"]["coordinates"][0]:
 					try:
-						cur.execute(self._prep("DELETE from geospatial where record_id = ?"), (record["record_id"],))
 						cur.execute(self._prep("INSERT INTO geospatial (record_id, coordinate_type, lat, lon) VALUES (?,?,?,?)"), (record["record_id"], record["geospatial"]["type"], coordinates[0], coordinates[1]))
 					except self.dblayer.IntegrityError:
 						pass
 
+			# TODO: Figure out how to handle the case when domain metadata removed from item in repo
 			for domain_metadata_element in domain_metadata:
 				if domain_metadata_element in record:
 					if not isinstance(record[domain_metadata_element], list):

--- a/harvester/DBInterface.py
+++ b/harvester/DBInterface.py
@@ -28,14 +28,14 @@ class DBInterface:
 			cur = con.cursor()
 			cur.execute("create table if not exists creators (creator_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, creator TEXT, is_contributor INTEGER)")
 			cur.execute("create table if not exists descriptions (description_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, description TEXT, language TEXT)")
-			cur.execute("create table if not exists domain_metadata (subject_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, field_name TEXT, field_value TEXT)")
-			cur.execute("create table if not exists geospatial (subject_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, coordinate_type TEXT, lat NUMERIC, lon NUMERIC)")
+			cur.execute("create table if not exists domain_metadata (metadata_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, field_name TEXT, field_value TEXT)")
+			cur.execute("create table if not exists geospatial (geospatial_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, coordinate_type TEXT, lat NUMERIC, lon NUMERIC)")
 			cur.execute("""create table if not exists records (record_id INTEGER PRIMARY KEY NOT NULL,repository_id INTEGER NOT NULL,title TEXT,pub_date TEXT,modified_timestamp INTEGER DEFAULT 0,
 				source_url TEXT,deleted NUMERIC DEFAULT 0,local_identifier TEXT,series TEXT,contact TEXT)""")
 			cur.execute("""create table if not exists repositories (repository_id INTEGER PRIMARY KEY NOT NULL,repository_set TEXT NOT NULL DEFAULT '',repository_url TEXT,repository_name TEXT,
 				repository_thumbnail TEXT,repository_type TEXT,last_crawl_timestamp INTEGER,item_url_pattern TEXT,abort_after_numerrors INTEGER,max_records_updated_per_run INTEGER,
 				update_log_after_numitems INTEGER,record_refresh_days INTEGER,repo_refresh_days INTEGER,enabled TEXT)""")
-			cur.execute("create table if not exists rights (subject_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, rights TEXT)")
+			cur.execute("create table if not exists rights (rights_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, rights TEXT)")
 			cur.execute("create table if not exists subjects (subject_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, subject TEXT)")
 			cur.execute("create table if not exists tags (tag_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, tag TEXT, language TEXT)")
 			cur.execute("create index if not exists creators_by_record on creators(record_id)")

--- a/harvester/Exporter.py
+++ b/harvester/Exporter.py
@@ -92,7 +92,7 @@ class Exporter(object):
 			if only_new_records == True and float(lastrun_timestamp) > record["last_crawl_timestamp"]:
 				continue
 
-			if (record['title'] < 1):
+			if (len(record['title']) == 0):
 				continue
 
 			record["dc:source"] = self._construct_local_url(record)

--- a/harvester/Exporter.py
+++ b/harvester/Exporter.py
@@ -73,7 +73,7 @@ class Exporter(object):
 			records_cursor = records_con.cursor()
 
 		records_cursor.execute(self.db._prep("""SELECT recs.record_id, recs.title, recs.pub_date, recs.contact, recs.series, recs.source_url, recs.deleted, recs.local_identifier, recs.modified_timestamp,
-			repos.repository_url, repos.repository_name as "nrdr:origin.id", repos.repository_thumbnail as "nrdr:origin.icon", repos.item_url_pattern, repos.last_crawl_timestamp 
+			repos.repository_url, repos.repository_name, repos.repository_thumbnail, repos.item_url_pattern, repos.last_crawl_timestamp 
 			FROM records recs, repositories repos WHERE recs.repository_id = repos.repository_id """))
 
 		records_assembled = 0
@@ -86,7 +86,8 @@ class Exporter(object):
 				self._write_to_file(json.dumps(gingest_block), export_filepath, temp_filepath, "gmeta", gmeta_batches)
 				del gmeta[:batch_size]
 
-			record = (dict(zip(['record_id','title', 'pub_date', 'contact', 'series', 'source_url', 'deleted', 'local_identifier', 'repository_url', 'nrdr:origin.id', 'nrdr:origin.icon', 'item_url_pattern', 'modified_timestamp', 'last_crawl_timestamp'], row)))
+			record = (dict(zip(['record_id','title', 'pub_date', 'contact', 'series', 'source_url', 'deleted', 'local_identifier', 'modified_timestamp',
+				'repository_url', 'repository_name', 'repository_thumbnail', 'item_url_pattern',  'last_crawl_timestamp'], row)))
 			record["deleted"] = int(record["deleted"])
 
 			if only_new_records == True and float(lastrun_timestamp) > record["last_crawl_timestamp"]:
@@ -171,20 +172,28 @@ class Exporter(object):
 					record[row[0]] = row[1]
 
 			# Convert friendly column names into dc element names
-			record["dc:title"] = record["title"]
-			record["dc:date"] = record["pub_date"]
-			record["nrdr:contact"] = record["contact"]
-			record["nrdr:series"] = record["series"]
+			record["dc:title"]         = record["title"]
+			record["dc:date"]          = record["pub_date"]
+			record["nrdr:contact"]     = record["contact"]
+			record["nrdr:series"]      = record["series"]
+			record["nrdr:origin.id"]   = record["repository_name"]
+			record["nrdr:origin.icon"] = record["repository_thumbnail"]
+
 			# remove unneeded columns from output
-			record.pop("title", None)
-			record.pop("pub_date", None)
 			record.pop("contact", None)
+			record.pop("deleted", None)
+			record.pop("item_url_pattern", None)
+			record.pop("last_crawl_timestamp", None)
+			record.pop("local_identifier", None)
+			record.pop("modified_timestamp", None)
+			record.pop("pub_date", None)
+			record.pop("record_id", None)
+			record.pop("repository_name", None)
+			record.pop("repository_thumbnail", None)
+			record.pop("repository_url", None)
 			record.pop("series", None)
 			record.pop("source_url", None)
-			record.pop("deleted", None)
-			record.pop("repository_url", None)
-			record.pop("local_identifier", None)
-			record.pop("record_id", None)
+			record.pop("title", None)
 
 			record["@context"] = {"dc": "http://dublincore.org/documents/dcmi-terms", "nrdr": "http://nrdr-ednr.ca/schema/1.0/", "datacite": "https://schema.labs.datacite.org/meta/kernel-4.0/metadata.xsd"}
 			record["datacite:resourceTypeGeneral"] = "dataset"

--- a/harvester/Exporter.py
+++ b/harvester/Exporter.py
@@ -72,22 +72,27 @@ class Exporter(object):
 		with records_con:
 			records_cursor = records_con.cursor()
 
-		records_cursor.execute(self.db._prep("""SELECT recs.title, recs.date, recs.contact, recs.series, recs.source_url, recs.deleted, recs.local_identifier, recs.repository_url, repos.repository_name as "nrdr:origin.id", repos.repository_thumbnail as "nrdr:origin.icon", repos.item_url_pattern, recs.modified_timestamp, repos.last_crawl_timestamp FROM records recs, repositories repos WHERE recs.title != '' and recs.repository_url = repos.repository_url """))
+		records_cursor.execute(self.db._prep("""SELECT recs.record_id, recs.title, recs.pub_date, recs.contact, recs.series, recs.source_url, recs.deleted, recs.local_identifier, recs.modified_timestamp,
+			repos.repository_url, repos.repository_name as "nrdr:origin.id", repos.repository_thumbnail as "nrdr:origin.icon", repos.item_url_pattern, repos.last_crawl_timestamp 
+			FROM records recs, repositories repos WHERE recs.repository_id = repos.repository_id """))
 
 		records_assembled = 0
 		gmeta_batches = 0
 		for row in records_cursor:
 			if records_assembled % batch_size == 0 and records_assembled!=0:
 				gmeta_batches += 1
+				self.logger.debug("Writing batch %s to output file" % (gmeta_batches))
 				gingest_block = {"@datatype": "GIngest", "@version": "2016-11-09", "source_id": "ComputeCanada", "ingest_type": "GMetaList", "ingest_data": {"@datatype": "GMetaList", "@version": "2016-11-09", "gmeta":gmeta}}
 				self._write_to_file(json.dumps(gingest_block), export_filepath, temp_filepath, "gmeta", gmeta_batches)
 				del gmeta[:batch_size]
 
-			record = (dict(zip(['title', 'date', 'contact', 'series', 'source_url', 'deleted', 'local_identifier', 'repository_url', 'nrdr:origin.id', 'nrdr:origin.icon', 'item_url_pattern', 'modified_timestamp', 'last_crawl_timestamp'], row)))
+			record = (dict(zip(['record_id','title', 'pub_date', 'contact', 'series', 'source_url', 'deleted', 'local_identifier', 'repository_url', 'nrdr:origin.id', 'nrdr:origin.icon', 'item_url_pattern', 'modified_timestamp', 'last_crawl_timestamp'], row)))
 			record["deleted"] = int(record["deleted"])
 
-
 			if only_new_records == True and float(lastrun_timestamp) > record["last_crawl_timestamp"]:
+				continue
+
+			if (record['title'] < 1):
 				continue
 
 			record["dc:source"] = self._construct_local_url(record)
@@ -108,8 +113,7 @@ class Exporter(object):
 				elif self.dbtype == "postgres":
 					litecur = con.cursor(cursor_factory=None)
 
-				litecur.execute(self.db._prep("SELECT coordinate_type, lat, lon FROM geospatial WHERE local_identifier=? AND repository_url=?"),
-					(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT coordinate_type, lat, lon FROM geospatial WHERE record_id=?"), (record["record_id"],) )
 				geodata = litecur.fetchall()
 				record["nrdr:geospatial"] = []
 				polycoordinates = []
@@ -137,57 +141,50 @@ class Exporter(object):
 
 				# attach the other values to the dict
 				# TODO: investigate doing this purely in SQL
-				litecur.execute(self.db._prep("SELECT creator FROM creators WHERE local_identifier=? AND repository_url=? AND is_contributor=0"),
-					(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT creator FROM creators WHERE record_id=? AND is_contributor=0"), (record["record_id"],) )
 				record["dc:contributor.author"] = litecur.fetchall()
 
-				litecur.execute(self.db._prep("SELECT creator FROM creators WHERE local_identifier=? AND repository_url=? AND is_contributor=1"),
-					(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT creator FROM creators WHERE record_id=? AND is_contributor=1"), (record["record_id"],) )
 				record["dc:contributor"] = litecur.fetchall()
 
-				litecur.execute(self.db._prep("SELECT subject FROM subjects WHERE local_identifier=? AND repository_url=?"),
-								(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT subject FROM subjects WHERE record_id=?"), (record["record_id"],) )
 				record["dc:subject"] = litecur.fetchall()
 
-				litecur.execute(self.db._prep("SELECT rights FROM rights WHERE local_identifier=? AND repository_url=?"),
-								(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT rights FROM rights WHERE record_id=?"), (record["record_id"],) )
 				record["dc:rights"] = litecur.fetchall()
 
-				litecur.execute(self.db._prep("SELECT description FROM descriptions WHERE local_identifier=? AND repository_url=?"),
-								(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT description FROM descriptions WHERE record_id=? and language='en' "), (record["record_id"],) )
 				record["dc:description"] = litecur.fetchall()
 
-				litecur.execute(self.db._prep("SELECT description FROM fra_descriptions WHERE local_identifier=? AND repository_url=?"),
-					(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT description FROM descriptions WHERE record_id=? and language='fr' "), (record["record_id"],) )
 				record["nrdr:description_fr"] = litecur.fetchall()
 
-				litecur.execute(self.db._prep("SELECT tag FROM tags WHERE local_identifier=? AND repository_url=? AND language='en'"),
-								(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT tag FROM tags WHERE record_id=? AND language='en'"), (record["record_id"],) )
 				record["nrdr:tags"] = litecur.fetchall()
 
-				litecur.execute(self.db._prep("SELECT tag FROM tags WHERE local_identifier=? AND repository_url=? AND language='fr'"),
-								(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT tag FROM tags WHERE record_id=? AND language='fr'"), (record["record_id"],) )
 				record["nrdr:tags_fr"] = litecur.fetchall()
 
-				litecur.execute(self.db._prep("SELECT field_name, field_value FROM domain_metadata WHERE local_identifier=? AND repository_url=?"),
-								(record["local_identifier"], record["repository_url"]))
+				litecur.execute(self.db._prep("SELECT field_name, field_value FROM domain_metadata WHERE record_id=?"), (record["record_id"],) )
 				domain_metadata = litecur.fetchall()
 				for row in domain_metadata:
 					record[row[0]] = row[1]
 
-				record.pop("repository_url", None)
-				record.pop("local_identifier", None)
-
+			# Convert friendly column names into dc element names
 			record["dc:title"] = record["title"]
-			record.pop("title", None)
-			record["dc:date"] = record["date"]
-			record.pop("date", None)
+			record["dc:date"] = record["pub_date"]
 			record["nrdr:contact"] = record["contact"]
-			record.pop("contact", None)
 			record["nrdr:series"] = record["series"]
+			# remove unneeded columns from output
+			record.pop("title", None)
+			record.pop("pub_date", None)
+			record.pop("contact", None)
 			record.pop("series", None)
 			record.pop("source_url", None)
 			record.pop("deleted", None)
+			record.pop("repository_url", None)
+			record.pop("local_identifier", None)
+			record.pop("record_id", None)
 
 			record["@context"] = {"dc": "http://dublincore.org/documents/dcmi-terms", "nrdr": "http://nrdr-ednr.ca/schema/1.0/", "datacite": "https://schema.labs.datacite.org/meta/kernel-4.0/metadata.xsd"}
 			record["datacite:resourceTypeGeneral"] = "dataset"
@@ -231,7 +228,6 @@ class Exporter(object):
 
 		try:
 			with open(temp_filename, "w") as tempfile:
-				self.logger.info("Writing output file")
 				tempfile.write(output)
 		except:
 			self.logger.error("Unable to write output data to temporary file: %s" % (temp_filename))

--- a/harvester/HarvestLogger.py
+++ b/harvester/HarvestLogger.py
@@ -1,7 +1,7 @@
 import os
 import logging
 import sys
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import RotatingFileHandler
 
 class HarvestLogger:
 
@@ -10,11 +10,10 @@ class HarvestLogger:
 		if not os.path.exists(self.logdir):
 			os.makedirs(self.logdir)
 
-		self.handler = TimedRotatingFileHandler(
-			params['filename'],
-			when="D",
-			interval=int(params['daysperfile']),
-			backupCount=int(params['keep'])
+		self.handler = RotatingFileHandler(
+			params.get('filename','logs/log.txt'),
+			maxBytes=int(params.get('maxbytes',10485760)),
+			backupCount=int(params.get('keep',7))
 		)
 		logFormatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 		self.handler.setFormatter(logFormatter)

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -69,7 +69,7 @@ class OAIRepository(HarvestRepository):
 			except AttributeError:
 				# probably not a valid OAI record
 				# Islandora throws this for non-object directories
-				self.logger.debug("OAI AttributeError with item %s" % (metadata["identifier"]) )
+				self.logger.debug("AttributeError while working on item %i" % (item_count))
 				pass
 
 			except StopIteration:

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -69,7 +69,7 @@ class OAIRepository(HarvestRepository):
 			except AttributeError:
 				# probably not a valid OAI record
 				# Islandora throws this for non-object directories
-				self.logger.debug("OAI AttributeError with item %s" % (oai_record["identifier"]) )
+				self.logger.debug("OAI AttributeError with item %s" % (metadata["identifier"]) )
 				pass
 
 			except StopIteration:
@@ -178,7 +178,6 @@ class OAIRepository(HarvestRepository):
 
 		# If dates are entirely numeric, add separators
 		if not re.search("\D", record["pub_date"]):
-			self.logger.debug("Trying to reformat date: %s" % (record["pub_date"]))
 			if (len(record["pub_date"]) == 6):
 				record["pub_date"] = record["pub_date"][0] + record["pub_date"][1] + record["pub_date"][2] + record["pub_date"][3] + "-" + record["pub_date"][4] + record["pub_date"][5]
 			if (len(record["pub_date"]) == 8):

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -69,6 +69,7 @@ class OAIRepository(HarvestRepository):
 			except AttributeError:
 				# probably not a valid OAI record
 				# Islandora throws this for non-object directories
+				self.logger.debug("OAI AttributeError with item %s" % (oai_record["identifier"]) )
 				pass
 
 			except StopIteration:
@@ -178,10 +179,8 @@ class OAIRepository(HarvestRepository):
 		# If dates are entirely numeric, add separators
 		if not re.search("\D", record["pub_date"]):
 			self.logger.debug("Trying to reformat date: %s" % (record["pub_date"]))
-			if (len(record["pub_date"]) == 4):
-				record["pub_date"] = record["pub_date"][0] + record["pub_date"][1] + record["pub_date"][2] + record["pub_date"][3] + "-01-01"
 			if (len(record["pub_date"]) == 6):
-				record["pub_date"] = record["pub_date"][0] + record["pub_date"][1] + record["pub_date"][2] + record["pub_date"][3] + "-" + record["pub_date"][4] + record["pub_date"][5] + "-01"
+				record["pub_date"] = record["pub_date"][0] + record["pub_date"][1] + record["pub_date"][2] + record["pub_date"][3] + "-" + record["pub_date"][4] + record["pub_date"][5]
 			if (len(record["pub_date"]) == 8):
 				record["pub_date"] = record["pub_date"][0] + record["pub_date"][1] + record["pub_date"][2] + record["pub_date"][3] + "-" + record["pub_date"][4] + record["pub_date"][5] + "-" + record["pub_date"][6] + record["pub_date"][7]
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Configuration, including which repos are to be crawled, should be placed in data
     "export_format": "gmeta",
     "logging": {
         "filename": "logs/log.txt",
-        "daysperfile": 1,
+        "maxbytes": 10485760,
         "keep": 7,
         "level": "DEBUG"
     },

--- a/update_schema.sql
+++ b/update_schema.sql
@@ -1,0 +1,141 @@
+create table repositories_temp (repository_id INTEGER PRIMARY KEY NOT NULL,repository_url TEXT NOT NULL, repository_set TEXT NOT NULL DEFAULT '', repository_name TEXT, repository_thumbnail TEXT,
+  repository_type TEXT,last_crawl_timestamp INTEGER,item_url_pattern TEXT,abort_after_numerrors INTEGER,max_records_updated_per_run INTEGER,update_log_after_numitems INTEGER,
+  record_refresh_days INTEGER, repo_refresh_days INTEGER, enabled INTEGER);
+begin transaction;
+insert into repositories_temp (repository_url,repository_name,repository_thumbnail,repository_type,last_crawl_timestamp,item_url_pattern,enabled)
+select repository_url,repository_name,repository_thumbnail,repository_type,last_crawl_timestamp,item_url_pattern,1 from repositories;
+commit;
+
+create table records_temp (record_id INTEGER PRIMARY KEY NOT NULL,repository_id INTEGER NOT NULL,title TEXT,pub_date TEXT,modified_timestamp INTEGER DEFAULT 0,source_url TEXT,deleted INTEGER DEFAULT 0,local_identifier TEXT,series TEXT,contact TEXT);
+begin transaction;
+insert into records_temp (repository_id,title,pub_date,modified_timestamp,source_url,deleted,local_identifier,series,contact)
+select rep1.repository_id,rec1.title,rec1.date,rec1.modified_timestamp,rec1.source_url,rec1.deleted,rec1.local_identifier,rec1.series,rec1.contact 
+from records rec1
+inner join repositories_temp rep1 on rep1.repository_url = rec1.repository_url;
+commit;
+
+create table creators_temp (creator_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, creator TEXT, is_contributor INTEGER);
+begin transaction;
+insert into creators_temp (record_id,creator,is_contributor)
+select rec1.record_id, cre1.creator,cre1.is_contributor
+from records_temp rec1
+inner join creators cre1 on cre1.local_identifier = rec1.local_identifier;
+commit;
+
+create table descriptions_temp (description_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, description TEXT, language TEXT);
+begin transaction;
+insert into descriptions_temp (record_id,description,language)
+select rec1.record_id, dis1.description, 'en'
+from records_temp rec1
+inner join descriptions dis1 on dis1.local_identifier = rec1.local_identifier;
+commit;
+
+begin transaction;
+insert into descriptions_temp (record_id,description,language)
+select rec1.record_id, dis1.description, 'fr'
+from records_temp rec1
+inner join fra_descriptions dis1 on dis1.local_identifier = rec1.local_identifier;
+commit;
+
+create table tags_temp (tag_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, tag TEXT, language TEXT);
+begin transaction;
+insert into tags_temp (record_id,tag,language)
+select rec1.record_id, tag1.tag, tag1.language
+from records_temp rec1
+inner join tags tag1 on tag1.local_identifier = rec1.local_identifier;
+commit;
+
+create table subjects_temp (subject_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, subject TEXT);
+begin transaction;
+insert into subjects_temp (record_id,subject)
+select rec1.record_id, sub1.subject
+from records_temp rec1
+inner join subjects sub1 on sub1.local_identifier = rec1.local_identifier;
+commit;
+
+create table rights_temp (rights_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, rights TEXT);
+begin transaction;
+insert into rights_temp (record_id,rights)
+select rec1.record_id, rig1.rights
+from records_temp rec1
+inner join rights rig1 on rig1.local_identifier = rec1.local_identifier;
+commit;
+
+create table geospatial_temp (geospatial_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, coordinate_type TEXT, lat NUMERIC, lon NUMERIC);
+begin transaction;
+insert into geospatial_temp (record_id,coordinate_type,lat,lon)
+select rec1.record_id, geo1.coordinate_type, geo1.lat, geo1.lon
+from records_temp rec1
+inner join geospatial geo1 on geo1.local_identifier = rec1.local_identifier;
+commit;
+
+create table domain_metadata_temp (metadata_id INTEGER PRIMARY KEY NOT NULL,record_id INTEGER NOT NULL, field_name TEXT, field_value TEXT);
+begin transaction;
+insert into domain_metadata_temp (record_id,field_name, field_value)
+select rec1.record_id, met1.field_name, met1.field_value
+from records_temp rec1
+inner join domain_metadata met1 on met1.local_identifier = rec1.local_identifier;
+commit;
+
+begin transaction;
+drop table repositories;
+alter table repositories_temp rename to repositories;
+commit;
+
+begin transaction;
+drop index identifier_plus_creator;
+drop table creators;
+alter table creators_temp rename to creators;
+create index creators_by_record on creators(record_id);
+commit;
+
+begin transaction;
+drop index identifier_plus_description;
+drop table descriptions;
+drop table fra_descriptions;
+alter table descriptions_temp rename to descriptions;
+create index descriptions_by_record on descriptions(record_id,language);
+commit;
+
+begin transaction;
+drop index identifier_plus_tag;
+drop table tags;
+alter table tags_temp rename to tags;
+create index tags_by_record on tags(record_id,language);
+commit;
+
+begin transaction;
+drop index identifier_plus_subject;
+drop table subjects;
+alter table subjects_temp rename to subjects;
+create index subjects_by_record on subjects(record_id);
+commit;
+
+begin transaction;
+drop index identifier_plus_rights;
+drop table rights;
+alter table rights_temp rename to rights;
+create index rights_by_record on rights(record_id);
+commit;
+
+begin transaction;
+drop index identifier_plus_lat_lon;
+drop table geospatial;
+alter table geospatial_temp rename to geospatial;
+create index geospatial_by_record on geospatial(record_id);
+commit;
+
+begin transaction;
+drop index domain_metadata_value;
+drop table domain_metadata;
+alter table domain_metadata_temp rename to domain_metadata;
+create index domain_metadata_by_record on domain_metadata(record_id);
+commit;
+
+begin transaction;
+drop table records;
+alter table records_temp rename to records;
+create unique index records_by_repository on records (repository_id, local_identifier);
+commit;
+
+vacuum;


### PR DESCRIPTION
- gmeta batch size lowered due to Globus server side constraints
- renamed column 'date' to 'pub_date' in records table
- switched to size-based log rolling since date-based was not working
- repositories that differ only in set now correctly identified as separate