### PR TITLE
Change the way that deletes are handled

### DIFF
--- a/harvester/DBInterface.py
+++ b/harvester/DBInterface.py
@@ -257,6 +257,18 @@ class DBInterface:
         self.logger.debug("Marked as deleted: record {}".format(record['local_identifier']))
         return True
 
+    def purge_deleted_records(self):
+        con = self.getConnection()
+        with con:
+            cur = self.getCursor(con)
+            try:
+                sqlstring = "DELETE from records where deleted=1"
+                cur.execute(sqlstring)
+            except:
+                return False
+
+        return True
+
     def delete_related_records(self, crosstable, record_id):
         con = self.getConnection()
         with con:

--- a/harvester/Exporter.py
+++ b/harvester/Exporter.py
@@ -105,6 +105,10 @@ class Exporter(object):
                  'last_crawl_timestamp'], row)))
             record["deleted"] = int(record["deleted"])
 
+            if record["deleted"] == 1:
+                deleted.append(record["dc:source"])
+                continue
+                
             if only_new_records == True and float(lastrun_timestamp) > record["last_crawl_timestamp"]:
                 continue
 
@@ -113,10 +117,6 @@ class Exporter(object):
 
             record["dc:source"] = self._construct_local_url(record)
             if record["dc:source"] is None:
-                continue
-
-            if record["deleted"] == 1:
-                deleted.append(record["dc:source"])
                 continue
 
             con = self.db.getConnection()

--- a/harvester/Exporter.py
+++ b/harvester/Exporter.py
@@ -105,18 +105,18 @@ class Exporter(object):
                  'last_crawl_timestamp'], row)))
             record["deleted"] = int(record["deleted"])
 
+            record["dc:source"] = self._construct_local_url(record)
+            if record["dc:source"] is None:
+                continue
+                
             if record["deleted"] == 1:
                 deleted.append(record["dc:source"])
                 continue
-                
+
             if only_new_records == True and float(lastrun_timestamp) > record["last_crawl_timestamp"]:
                 continue
 
             if (len(record['title']) == 0):
-                continue
-
-            record["dc:source"] = self._construct_local_url(record)
-            if record["dc:source"] is None:
                 continue
 
             con = self.db.getConnection()

--- a/index_admin.py
+++ b/index_admin.py
@@ -109,13 +109,19 @@ def delete_items_by_curl(delete_id_list, index_uuid, token):
         r = requests.post('https://' + _api_host + '/v1/index/' + index_uuid + '/delete_by_query', headers=headers, json=queryobj)
         results = json.loads(r.text)
         if "num_subjects_deleted" in results:
-            LOGGER.info("Deleted {} item(s)".format(results.get('num_subjects_deleted')))
+            continue
         else:
             LOGGER.info("Error deleting item: {}\n{}".format(item, r.text))
-            continue
 
     get_db().purge_deleted_records()
 
+def get_config_ini(config_file):
+    c = configparser.ConfigParser()
+    try:
+        c.read(config_file)
+        return c
+    except:
+        return None
 
 def main():
     global LOGGER
@@ -127,6 +133,7 @@ def main():
     logging.basicConfig(level=logging.INFO, format=log_format, handlers=[syslog_handler, stderr_handler])
     LOGGER = logging.getLogger('__name__')
     CONFIG["db"] = get_config_ini("conf/harvester.conf")["db"]
+    get_db().setLogger(LOGGER)
 
     cl_parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     try:

--- a/index_admin.py
+++ b/index_admin.py
@@ -8,6 +8,7 @@ import os
 import time
 import traceback
 import requests
+from harvester.DBInterface import DBInterface
 
 """
 Utility application to manage Globus Search Indexes for FRDR.
@@ -18,7 +19,13 @@ If running on a new host you will likely have to authorize it by running a query
 _cmd = "/opt/rdm/search_client/search-client"
 _api_host = "search.api.globus.org"
 _tokens_filepath = "/home/harvest/.globus_search_client_tokens.json"
+CONFIG = {"db": None, "handles": {}}
 
+
+def get_db():
+    if "db" not in CONFIG["handles"]:
+        CONFIG["handles"]["db"] = DBInterface(CONFIG['db'])
+    return CONFIG["handles"]["db"]
 
 def get_index_config(config_file="conf/globus-indexes.conf"):
     '''
@@ -105,16 +112,21 @@ def delete_items_by_curl(delete_id_list, index_uuid, token):
             LOGGER.info("Deleted {} item(s)".format(results.get('num_subjects_deleted')))
         else:
             LOGGER.info("Error deleting item: {}\n{}".format(item, r.text))
+            continue
+
+    get_db().purge_deleted_records()
 
 
 def main():
     global LOGGER
+    global CONFIG
     syslog_handler = logging.handlers.SysLogHandler()
     stderr_handler = logging.StreamHandler()
     log_format = ('%(levelname) -10s %(asctime)s %(name) -30s %(funcName) '
                   '-35s %(lineno) -5d: %(message)s')
     logging.basicConfig(level=logging.INFO, format=log_format, handlers=[syslog_handler, stderr_handler])
     LOGGER = logging.getLogger('__name__')
+    CONFIG["db"] = get_config_ini("conf/harvester.conf")["db"]
 
     cl_parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     try:


### PR DESCRIPTION
I completed the last part of the cycle: purging the records from the database once they were deleted from the search index.

Normal operation:
  - harvest is run; deleted records are marked for deletion
  - export is run; records are dumped out to the delete file
  - index update is run; records are removed from the search index
  - index administration is run; records are purged from the db

There is a small possibility for a race condition:
  - harvest is run; deleted records are marked for deletion
  - export is run; records are dumped out to the delete file
  - index update is started but not yet done deleting things
  - a new harvest starts up at this exact instant, and starts adding more deleted records to the db
  - the index update now finishes
  - index administration is run; records are purged from the db, including the just-added ones

In this situation, records would be purged from the database without ever being removed from the search index.  I think there is a small chance this will happen and the search index will drift over time, however there isn't any real damage done by this since most repositories will just show "sorry this item has been deleted".
